### PR TITLE
Feat clarify username type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is an unofficial integration of Cellar Tracker for Home Assistant. The deve
 1. Install manually by copying the `custom_components/wine_cellar` folder into `<config_dir>/custom_components`.
 2. Restart Home Assistant.
 3. In the Home Assistant UI, navigate to `Settings` then `Devices & services`. In the `Integrations` tab, click on the `ADD INTEGRATION` button at the bottom right and select `Wine Cellar`. Fill out the options and save.
-   - Username - Your cellartracker.com Member Name (NOT your Email Address).
+   - Member Name - Your cellartracker.com Member Name (NOT your Email Address).
    - Password - Your cellartracker.com password.
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This is an unofficial integration of Cellar Tracker for Home Assistant. The deve
 1. Install manually by copying the `custom_components/wine_cellar` folder into `<config_dir>/custom_components`.
 2. Restart Home Assistant.
 3. In the Home Assistant UI, navigate to `Settings` then `Devices & services`. In the `Integrations` tab, click on the `ADD INTEGRATION` button at the bottom right and select `Wine Cellar`. Fill out the options and save.
-   - Username - Your cellartracker.com Member Name.
+   - Username - Your cellartracker.com Member Name (NOT your Email Address).
    - Password - Your cellartracker.com password.
 ## Usage
 

--- a/custom_components/wine_cellar/config_flow.py
+++ b/custom_components/wine_cellar/config_flow.py
@@ -38,7 +38,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     await hass.async_add_executor_job(client.get_food_tag)
 
     # Return info that you want to store in the config entry.
-    return {"title": "Wine Cellar"}
+    return {"title": "Wine Cellar of " + data[CONF_USERNAME]}
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/wine_cellar/manifest.json
+++ b/custom_components/wine_cellar/manifest.json
@@ -11,6 +11,6 @@
   "iot_class": "cloud_polling",
   "requirements": [ "cellartracker==1.1.1" ],
   "ssdp": [],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "zeroconf": []
 }

--- a/custom_components/wine_cellar/strings.json
+++ b/custom_components/wine_cellar/strings.json
@@ -6,7 +6,7 @@
       "user": {
         "title": "cellartracker.com Credentials",
         "data": {
-          "username": "Username",
+          "username": "Member Name",
           "password": "Password"
         }
       }

--- a/custom_components/wine_cellar/translations/en.json
+++ b/custom_components/wine_cellar/translations/en.json
@@ -6,7 +6,7 @@
       "user": {
         "title": "cellartracker.com Credentials",
         "data": {
-          "username": "Username",
+          "username": "Member Name",
           "password": "Password"
         }
       }


### PR DESCRIPTION
Change `ADD ENTRY` credentials prompt from `Username` to `Member Name` to emphasize that email address cannot be used with an API login.